### PR TITLE
Updated docker network mode

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
   bouncer-mikrotik:
     image: ghcr.io/funkolab/cs-mikrotik-bouncer:latest
+    network_mode: "host"
     container_name: bouncer-mikrotik
     environment:
       CROWDSEC_BOUNCER_API_KEY: MyApiKey


### PR DESCRIPTION
By using network_mode host, you can comunicate with the crowdsec api since by default they listen only to 127.0.0.1:8080