### PR TITLE
Fix: update go-routeros to support new response format of ROS 7.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.5
 require (
 	github.com/crowdsecurity/crowdsec v1.6.4
 	github.com/crowdsecurity/go-cs-bouncer v0.0.14
-	github.com/go-routeros/routeros v0.0.0-20210123142807-2a44d57c6730
+	github.com/go-routeros/routeros/v3 v3.0.1
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/viper v1.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.17.0 h1:SmVVlfAOtlZncTxRuinDPomC2DkXJ4E5T9gDA0AIH74=
 github.com/go-playground/validator/v10 v10.17.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
-github.com/go-routeros/routeros v0.0.0-20210123142807-2a44d57c6730 h1:EuqwWLv/LPPjhvFqkeD2bz+FOlvw2DjvDI7vK8GVeyY=
-github.com/go-routeros/routeros v0.0.0-20210123142807-2a44d57c6730/go.mod h1:em1mEqFKnoeQuQP9Sg7i26yaW8o05WwcNj7yLhrXxSQ=
+github.com/go-routeros/routeros/v3 v3.0.1 h1:FdNKlF6Hst8nkHr0dIvD54pQ+dZ8sHOJfQSVRKz0BFg=
+github.com/go-routeros/routeros/v3 v3.0.1/go.mod h1:j4mq65czXfKtHsdLkgVv8w7sNzyhLZy1TKi2zQDMpiQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-routeros/routeros"
+	"github.com/go-routeros/routeros/v3"
 	"github.com/rs/zerolog/log"
 
 	"golang.org/x/sync/errgroup"

--- a/mikrotik.go
+++ b/mikrotik.go
@@ -7,7 +7,7 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/rs/zerolog/log"
 
-	"github.com/go-routeros/routeros"
+	"github.com/go-routeros/routeros/v3"
 )
 
 func dial() (*routeros.Client, error) {


### PR DESCRIPTION
Due to the last update of ROS, Mikrotik announced a change in API response if the response is empty like this:
"put !empty sentence when API query returns nothing;"

[RouterOS 7.18 Changelog](https://download.mikrotik.com/routeros/7.18/CHANGELOG)

With this change, Mikrotik-bouncer can use the latest version of the "go-routeros" package that supports all versions of the ROS API. 
[go-routeros releasenote](https://github.com/go-routeros/routeros/releases/tag/v3.0.1)


Issue #74 is related to this change and could be solved with it.